### PR TITLE
Fix derived-plot alignment and cursor stability under zoom/EOF

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ['macos-latest', 'ubuntu-22.04', 'ubuntu-20.04']
+        os: ['macos-latest', 'ubuntu-24.04', 'ubuntu-22.04']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,21 +16,35 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: ['macos-latest', 'ubuntu-24.04', 'ubuntu-22.04']
+        qt: ['qt5', 'qt6']
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
 
+    - name: Set variables Qt5
+      run: |
+        echo "QTPKG_MAC=qt@5" >> $GITHUB_ENV
+        echo "QTPKG_UBUNTU=qtbase5-dev" >> $GITHUB_ENV
+      if: matrix.qt == 'qt5'
+
+    - name: Set variables Qt6
+      run: |
+        echo "QTPKG_MAC=qt@6" >> $GITHUB_ENV
+        echo "QTPKG_UBUNTU=qt6-base-dev" >> $GITHUB_ENV
+      if: matrix.qt == 'qt6'
+
     - name: Install dependencies (macOS)
-      run: brew install fftw liquid-dsp qt@5
+      run: brew install fftw liquid-dsp ${{ env.QTPKG_MAC }}
       if: matrix.os == 'macos-latest'
 
     - name: Install dependencies (Ubuntu)
       run: |
         sudo apt update
-        sudo apt install libfftw3-dev libliquid-dev qtbase5-dev
+        sudo apt install libfftw3-dev libliquid-dev libgl1-mesa-dev ${{ env.QTPKG_UBUNTU }}
       if: startsWith(matrix.os, 'ubuntu-')
 
     - name: Create Build Environment

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(inspectrum CXX)
 enable_testing()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,8 +52,10 @@ list(APPEND inspectrum_sources
     util.cpp
 )
 
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Concurrent REQUIRED)
+find_package(Qt6 COMPONENTS Core Concurrent Widgets)
+if (NOT Qt6_FOUND)
+    find_package(Qt5 REQUIRED COMPONENTS Core Concurrent Widgets)
+endif()
 find_package(FFTW REQUIRED)
 find_package(Liquid REQUIRED)
 
@@ -64,11 +66,19 @@ include_directories(
 
 add_executable(inspectrum ${EXE_ARGS} ${inspectrum_sources})
 
-target_link_libraries(inspectrum
-    Qt5::Core Qt5::Widgets Qt5::Concurrent
-    ${FFTW_LIBRARIES}
-    ${LIQUID_LIBRARIES}
-)
+if (Qt6_FOUND)
+    target_link_libraries(inspectrum
+        Qt6::Core Qt6::Widgets Qt6::Concurrent
+        ${FFTW_LIBRARIES}
+        ${LIQUID_LIBRARIES}
+    )
+else()
+    target_link_libraries(inspectrum
+        Qt5::Core Qt5::Widgets Qt5::Concurrent
+        ${FFTW_LIBRARIES}
+        ${LIQUID_LIBRARIES}
+    )
+endif()
 
 set(INSTALL_DEFAULT_BINDIR "bin" CACHE STRING "Appended to CMAKE_INSTALL_PREFIX")
 

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -41,13 +41,13 @@ bool Cursor::mouseEvent(QEvent::Type type, QMouseEvent *event)
 {
     // If the mouse pointer moves over a cursor, display a resize pointer
     if (pointOverCursor(event->pos()) && type != QEvent::Leave) {
-        if (!cursorOverrided) {
-            cursorOverrided = true;
+        if (!cursorOverriden) {
+            cursorOverriden = true;
             QApplication::setOverrideCursor(QCursor(cursorShape));
         }
     // Restore pointer if it moves off the cursor, or leaves the widget
-    } else if (cursorOverrided) {
-        cursorOverrided = false;
+    } else if (cursorOverriden) {
+        cursorOverriden = false;
         QApplication::restoreOverrideCursor();
     }
 

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -37,10 +37,10 @@ bool Cursor::pointOverCursor(QPoint point)
     return range.contains(fromPoint(point));
 }
 
-bool Cursor::mouseEvent(QEvent::Type type, QMouseEvent event)
+bool Cursor::mouseEvent(QEvent::Type type, QMouseEvent *event)
 {
     // If the mouse pointer moves over a cursor, display a resize pointer
-    if (pointOverCursor(event.pos()) && type != QEvent::Leave) {
+    if (pointOverCursor(event->pos()) && type != QEvent::Leave) {
         if (!cursorOverrided) {
             cursorOverrided = true;
             QApplication::setOverrideCursor(QCursor(cursorShape));
@@ -53,8 +53,8 @@ bool Cursor::mouseEvent(QEvent::Type type, QMouseEvent event)
 
     // Start dragging on left mouse button press, if over a cursor
     if (type == QEvent::MouseButtonPress) {
-        if (event.button() == Qt::LeftButton) {
-            if (pointOverCursor(event.pos())) {
+        if (event->button() == Qt::LeftButton) {
+            if (pointOverCursor(event->pos())) {
                 dragging = true;
                 return true;
             }
@@ -63,13 +63,13 @@ bool Cursor::mouseEvent(QEvent::Type type, QMouseEvent event)
     // Update current cursor position if we're dragging
     } else if (type == QEvent::MouseMove) {
         if (dragging) {
-            cursorPosition = fromPoint(event.pos());
+            cursorPosition = fromPoint(event->pos());
             emit posChanged();
         }
 
     // Stop dragging on left mouse button release
     } else if (type == QEvent::MouseButtonRelease) {
-        if (event.button() == Qt::LeftButton && dragging) {
+        if (event->button() == Qt::LeftButton && dragging) {
             dragging = false;
             return true;
         }

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -40,12 +40,12 @@ bool Cursor::pointOverCursor(QPoint point)
 bool Cursor::mouseEvent(QEvent::Type type, QMouseEvent *event)
 {
     // If the mouse pointer moves over a cursor, display a resize pointer
-    if (pointOverCursor(event->pos()) && type != QEvent::Leave) {
+    if (pointOverCursor(event->pos())) {
         if (!cursorOverriden) {
             cursorOverriden = true;
             QApplication::setOverrideCursor(QCursor(cursorShape));
         }
-    // Restore pointer if it moves off the cursor, or leaves the widget
+    // Restore pointer if it moves off the cursor
     } else if (cursorOverriden) {
         cursorOverriden = false;
         QApplication::restoreOverrideCursor();
@@ -75,6 +75,14 @@ bool Cursor::mouseEvent(QEvent::Type type, QMouseEvent *event)
         }
     }
     return false;
+}
+
+void Cursor::leaveEvent()
+{
+    if (cursorOverriden) {
+        cursorOverriden = false;
+        QApplication::restoreOverrideCursor();
+    }
 }
 
 int Cursor::pos()

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -33,6 +33,7 @@ public:
     int pos();
     void setPos(int newPos);
     bool mouseEvent(QEvent::Type type, QMouseEvent *event);
+    void leaveEvent();
 
 signals:
     void posChanged();

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -32,7 +32,7 @@ public:
     Cursor(Qt::Orientation orientation, Qt::CursorShape mouseCursorShape, QObject * parent);
     int pos();
     void setPos(int newPos);
-    bool mouseEvent(QEvent::Type type, QMouseEvent event);
+    bool mouseEvent(QEvent::Type type, QMouseEvent *event);
 
 signals:
     void posChanged();

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -44,6 +44,6 @@ private:
     Qt::Orientation orientation;
     Qt::CursorShape cursorShape;
     bool dragging = false;
-    bool cursorOverrided = false;
+    bool cursorOverriden = false;
     int cursorPosition = 0;
 };

--- a/src/cursors.cpp
+++ b/src/cursors.cpp
@@ -44,15 +44,15 @@ bool Cursors::pointWithinDragRegion(QPoint point) {
     return range.contains(point.x());
 }
 
-bool Cursors::mouseEvent(QEvent::Type type, QMouseEvent event)
+bool Cursors::mouseEvent(QEvent::Type type, QMouseEvent *event)
 {
     if (minCursor->mouseEvent(type, event))
         return true;
     if (maxCursor->mouseEvent(type, event))
-    return true;
+        return true;
 
     // If the mouse pointer is between the cursors, display a resize pointer
-    if (pointWithinDragRegion(event.pos()) && type != QEvent::Leave) {
+    if (pointWithinDragRegion(event->pos()) && type != QEvent::Leave) {
         if (!cursorOverride) {
                 cursorOverride = true;
                 QApplication::setOverrideCursor(QCursor(Qt::SizeAllCursor));
@@ -66,25 +66,25 @@ bool Cursors::mouseEvent(QEvent::Type type, QMouseEvent event)
     }
     // Start dragging on left mouse button press, if between the cursors
     if (type == QEvent::MouseButtonPress) {
-        if (event.button() == Qt::LeftButton) {
-            if (pointWithinDragRegion(event.pos())) {
+        if (event->button() == Qt::LeftButton) {
+            if (pointWithinDragRegion(event->pos())) {
                 dragging = true;
-                dragPos = event.pos();
+                dragPos = event->pos();
                 return true;
             }
         }
     // Update both cursor positons if we're dragging
     } else if (type == QEvent::MouseMove) {
         if (dragging) {
-            int dx = event.pos().x() - dragPos.x();
+            int dx = event->pos().x() - dragPos.x();
             minCursor->setPos(minCursor->pos() + dx);
             maxCursor->setPos(maxCursor->pos() + dx);
-            dragPos = event.pos();
+            dragPos = event->pos();
             emit cursorsMoved();
         }
     // Stop dragging on left mouse button release
     } else if (type == QEvent::MouseButtonRelease) {
-        if (event.button() == Qt::LeftButton && dragging) {
+        if (event->button() == Qt::LeftButton && dragging) {
             dragging = false;
             return true;
         }

--- a/src/cursors.cpp
+++ b/src/cursors.cpp
@@ -52,7 +52,7 @@ bool Cursors::mouseEvent(QEvent::Type type, QMouseEvent *event)
         return true;
 
     // If the mouse pointer is between the cursors, display a resize pointer
-    if (pointWithinDragRegion(event->pos()) && type != QEvent::Leave) {
+    if (pointWithinDragRegion(event->pos()) ) {
         if (!cursorOverride) {
                 cursorOverride = true;
                 QApplication::setOverrideCursor(QCursor(Qt::SizeAllCursor));
@@ -90,6 +90,17 @@ bool Cursors::mouseEvent(QEvent::Type type, QMouseEvent *event)
         }
     }
     return false;
+}
+
+void Cursors::leaveEvent()
+{
+    minCursor->leaveEvent();
+    maxCursor->leaveEvent();
+
+    if (cursorOverride) {
+        cursorOverride = false;
+        QApplication::restoreOverrideCursor();
+    }
 }
 
 void Cursors::paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)

--- a/src/cursors.h
+++ b/src/cursors.h
@@ -33,7 +33,7 @@ class Cursors : public QObject
 public:
     Cursors(QObject * parent);
     int segments();
-    bool mouseEvent(QEvent::Type type, QMouseEvent event);
+    bool mouseEvent(QEvent::Type type, QMouseEvent *event);
     void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     range_t<int> selection();
     void setSegments(int segments);

--- a/src/cursors.h
+++ b/src/cursors.h
@@ -34,6 +34,7 @@ public:
     Cursors(QObject * parent);
     int segments();
     bool mouseEvent(QEvent::Type type, QMouseEvent *event);
+    void leaveEvent();
     void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     range_t<int> selection();
     void setSegments(int segments);

--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -348,7 +348,9 @@ QJsonObject InputSource::readMetaData(const QString &filename)
 
                 auto sigmf_color = sigmf_annotation["presentation:color"].toString();
                 // SigMF uses the format "#RRGGBBAA" for alpha-channel colors, QT uses "#AARRGGBB"
-                if ((sigmf_color.at(0) == '#') && (sigmf_color.length()) == 9) {
+                // Check length first so the empty/short-string case short-circuits before at(0):
+                // in Qt6 an empty QString has a null data pointer and at(0) would crash.
+                if ((sigmf_color.length() == 9) && (sigmf_color.at(0) == '#')) {
                     sigmf_color = "#" + sigmf_color.mid(7,2) + sigmf_color.mid(1,6);
                 }
                 auto boxColor = QString::fromStdString("white");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -72,12 +72,13 @@ void MainWindow::openFile(QString fileName)
 
     // Try to parse osmocom_fft filenames and extract the sample rate and center frequency.
     // Example file name: "name-f2.411200e+09-s5.000000e+06-t20160807180210.cfile"
-    QRegExp rx("(.*)-f(.*)-s(.*)-.*\\.cfile");
+    QRegularExpression rx(QRegularExpression::anchoredPattern("(.*)-f(.*)-s(.*)-.*\\.cfile"));
     QString basename = fileName.section('/',-1,-1);
 
-    if (rx.exactMatch(basename)) {
-        QString centerfreq = rx.cap(2);
-        QString samplerate = rx.cap(3);
+    auto match = rx.match(basename);
+    if (match.hasMatch()) {
+        QString centerfreq = match.captured(2);
+        QString samplerate = match.captured(3);
 
         std::stringstream ss(samplerate.toUtf8().constData());
 

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -39,6 +39,11 @@ bool Plot::mouseEvent(QEvent::Type type, QMouseEvent *event)
     return false;
 }
 
+void Plot::leaveEvent()
+{
+
+}
+
 std::shared_ptr<AbstractSampleSource> Plot::output()
 {
     return sampleSource;

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -34,7 +34,7 @@ void Plot::invalidateEvent()
 
 }
 
-bool Plot::mouseEvent(QEvent::Type type, QMouseEvent event)
+bool Plot::mouseEvent(QEvent::Type type, QMouseEvent *event)
 {
     return false;
 }

--- a/src/plot.h
+++ b/src/plot.h
@@ -34,6 +34,7 @@ public:
     ~Plot();
     void invalidateEvent() override;
     virtual bool mouseEvent(QEvent::Type type, QMouseEvent *event);
+    virtual void leaveEvent();
     virtual std::shared_ptr<AbstractSampleSource> output();
     virtual void paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     virtual void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);

--- a/src/plot.h
+++ b/src/plot.h
@@ -33,7 +33,7 @@ public:
     Plot(std::shared_ptr<AbstractSampleSource> src);
     ~Plot();
     void invalidateEvent() override;
-    virtual bool mouseEvent(QEvent::Type type, QMouseEvent event);
+    virtual bool mouseEvent(QEvent::Type type, QMouseEvent *event);
     virtual std::shared_ptr<AbstractSampleSource> output();
     virtual void paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     virtual void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -260,15 +260,16 @@ bool PlotView::viewportEvent(QEvent *event) {
 
         int plotY = -verticalScrollBar()->value();
         for (auto&& plot : plots) {
+            auto mouse_event = QMouseEvent(
+                event->type(),
+                QPoint(mouseEvent->position().x(), mouseEvent->position().y() - plotY),
+                mouseEvent->button(),
+                mouseEvent->buttons(),
+                QApplication::keyboardModifiers()
+            );
             bool result = plot->mouseEvent(
                 event->type(),
-                QMouseEvent(
-                    event->type(),
-                    QPoint(mouseEvent->pos().x(), mouseEvent->pos().y() - plotY),
-                    mouseEvent->button(),
-                    mouseEvent->buttons(),
-                    QApplication::keyboardModifiers()
-                )
+                &mouse_event
             );
             if (result)
                 return true;
@@ -276,7 +277,7 @@ bool PlotView::viewportEvent(QEvent *event) {
         }
 
         if (cursorsEnabled)
-            if (cursors.mouseEvent(event->type(), *mouseEvent))
+            if (cursors.mouseEvent(event->type(), mouseEvent))
                 return true;
     }
 

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -253,8 +253,7 @@ bool PlotView::viewportEvent(QEvent *event) {
     // Pass mouse events to individual plot objects
     if (event->type() == QEvent::MouseButtonPress ||
         event->type() == QEvent::MouseMove ||
-        event->type() == QEvent::MouseButtonRelease ||
-        event->type() == QEvent::Leave) {
+        event->type() == QEvent::MouseButtonRelease) {
 
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
 
@@ -279,6 +278,15 @@ bool PlotView::viewportEvent(QEvent *event) {
         if (cursorsEnabled)
             if (cursors.mouseEvent(event->type(), mouseEvent))
                 return true;
+    }
+
+    if (event->type() == QEvent::Leave) {
+        for (auto&& plot : plots) {
+            plot->leaveEvent();
+        }
+
+        if (cursorsEnabled)
+            cursors.leaveEvent();
     }
 
     // Handle parent eveents

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -91,7 +91,11 @@ void PlotView::updateAnnotationTooltip(QMouseEvent *event)
     } else {
         QString* comment = spectrogramPlot->mouseAnnotationComment(event);
         if (comment != nullptr) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            QToolTip::showText(event->globalPosition().toPoint(), *comment);
+#else
             QToolTip::showText(event->globalPos(), *comment);
+#endif
         } else {
             QToolTip::hideText();
         }
@@ -261,7 +265,11 @@ bool PlotView::viewportEvent(QEvent *event) {
         for (auto&& plot : plots) {
             auto mouse_event = QMouseEvent(
                 event->type(),
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
                 QPoint(mouseEvent->position().x(), mouseEvent->position().y() - plotY),
+#else
+                QPoint(mouseEvent->pos().x(), mouseEvent->pos().y() - plotY),
+#endif
                 mouseEvent->button(),
                 mouseEvent->buttons(),
                 QApplication::keyboardModifiers()

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -833,6 +833,14 @@ void PlotView::setFFTAndZoom(int size, int zoom)
     if (verticalScrollBar()->maximum() == 0)
         oldPlotCenter = 0.5;
 
+    // Pin the cursors to absolute SAMPLE positions across the zoom change.
+    // The cursors store their position in viewport pixels; after zoom those
+    // pixels span a different sample count, so the symbol-rate / period
+    // readout would silently drift just because the user zoomed. Save the
+    // samples now and re-place the cursors on the new pixel grid below.
+    bool reanchorCursors = cursorsEnabled;
+    range_t<size_t> savedCursorSamples = selectedSamples;
+
     // Set new FFT size
     fftSize = size;
     if (spectrogramPlot != nullptr)
@@ -862,6 +870,22 @@ void PlotView::setFFTAndZoom(int size, int zoom)
     // maintain the relative position of the vertical scroll bar
     if (verticalScrollBar()->maximum())
         verticalScrollBar()->setValue((int )(oldPlotCenter * plotsHeight() - viewport()->height() / 2.0 + 0.5f));
+
+    // Re-place the cursors at their saved sample positions on the new pixel
+    // grid. cursors.setSelection() takes viewport-pixel coordinates, so we
+    // subtract the new scrollbar value to get there. updateView()'s own
+    // cursor refresh runs from selectedSamples too but can be perturbed by
+    // the cursorsMoved() signal cascade that fires during setSelection; this
+    // final write nails the canonical value back down.
+    if (reanchorCursors) {
+        int sb = horizontalScrollBar()->value();
+        int minPx = static_cast<int>(sampleToColumn(savedCursorSamples.minimum)) - sb;
+        int maxPx = static_cast<int>(sampleToColumn(savedCursorSamples.maximum)) - sb;
+        cursors.setSelection({minPx, maxPx});
+        selectedSamples = savedCursorSamples;
+        emitTimeSelection();
+        viewport()->update();
+    }
 }
 
 void PlotView::setPowerMin(int power)

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -124,6 +124,10 @@ void PlotView::addPlot(Plot *plot)
 {
     plots.emplace_back(plot);
     connect(plot, &Plot::repaint, this, &PlotView::repaint);
+    // Seed any derived TracePlot with the global samples-per-pixel so it
+    // shares the spectrogram's x-axis from the moment it's added.
+    if (auto trace = dynamic_cast<TracePlot*>(plot))
+        trace->setSamplesPerColumn(samplesPerColumn());
 }
 
 void PlotView::addSpectrumPlot()
@@ -840,6 +844,13 @@ void PlotView::setFFTAndZoom(int size, int zoom)
     if (spectrogramPlot != nullptr) {
         spectrogramPlot->setZoomLevel(zoomLevel);
         spectrogramPlot->setSkip(nfftSkip);
+    }
+
+    // Propagate the new samples-per-pixel to any TracePlot (envelope, IFR,
+    // phase, threshold, etc.) so they redraw at the spectrogram's x-scale.
+    for (auto&& p : plots) {
+        if (auto trace = dynamic_cast<TracePlot*>(p.get()))
+            trace->setSamplesPerColumn(samplesPerColumn());
     }
 
     // Update horizontal (time) scrollbar

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -359,6 +359,12 @@ bool SpectrogramPlot::mouseEvent(QEvent::Type type, QMouseEvent *event)
     return false;
 }
 
+void SpectrogramPlot::leaveEvent()
+{
+    if (tunerEnabled())
+        tuner.leaveEvent();
+}
+
 std::shared_ptr<AbstractSampleSource> SpectrogramPlot::output()
 {
     return tunerTransform;

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -351,7 +351,7 @@ int SpectrogramPlot::linesPerTile()
     return tileSize / fftSize;
 }
 
-bool SpectrogramPlot::mouseEvent(QEvent::Type type, QMouseEvent event)
+bool SpectrogramPlot::mouseEvent(QEvent::Type type, QMouseEvent *event)
 {
     if (tunerEnabled())
         return tuner.mouseEvent(type, event);

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -343,18 +343,46 @@ float* SpectrogramPlot::getFFTTile(size_t tile)
 void SpectrogramPlot::getLine(float *dest, size_t sample)
 {
     if (inputSource && fft) {
-        // Make sample be the midpoint of the FFT, unless this takes us
-        // past the beginning of the inputSource (if we remove the
-        // std::max(·, 0), then an ugly red bar appears at the beginning
-        // of the spectrogram with large zooms and FFT sizes).
-        const auto first_sample = std::max(static_cast<ssize_t>(sample) - fftSize / 2,
-                        static_cast<ssize_t>(0));
-        auto buffer = inputSource->getSamples(first_sample, fftSize);
+        // Centre the FFT on `sample`. Clamp at the head of the file (otherwise
+        // an ugly red bar appears with large zooms and FFT sizes) and at the
+        // tail too -- previously when first_sample + fftSize exceeded EOF,
+        // getSamples returned null and we filled the column with -inf. That
+        // made the spectrogram visibly end fftSize/2 samples short of the
+        // trace plots' right edge. Zero-pad the partial buffer instead so the
+        // spectrogram and the trace plots stop at the same x-pixel.
+        const ssize_t available = static_cast<ssize_t>(inputSource->count());
+        ssize_t first_sample = static_cast<ssize_t>(sample) - fftSize / 2;
+        if (first_sample < 0)
+            first_sample = 0;
+
+        if (first_sample >= available) {
+            auto neg_infinity = -1 * std::numeric_limits<float>::infinity();
+            for (int i = 0; i < fftSize; i++, dest++)
+                *dest = neg_infinity;
+            return;
+        }
+
+        ssize_t want = fftSize;
+        if (first_sample + want > available)
+            want = available - first_sample;
+
+        auto buffer = inputSource->getSamples(first_sample, want);
         if (buffer == nullptr) {
             auto neg_infinity = -1 * std::numeric_limits<float>::infinity();
             for (int i = 0; i < fftSize; i++, dest++)
                 *dest = neg_infinity;
             return;
+        }
+
+        // Zero-pad to fftSize when getSamples returned a partial buffer at
+        // EOF. Cheaper than resizing in place -- we just need contiguous
+        // storage of length fftSize for the FFT.
+        if (want < fftSize) {
+            auto padded = std::make_unique<std::complex<float>[]>(fftSize);
+            std::copy(buffer.get(), buffer.get() + want, padded.get());
+            for (ssize_t i = want; i < fftSize; i++)
+                padded[i] = std::complex<float>(0.0f, 0.0f);
+            buffer = std::move(padded);
         }
 
         for (int i = 0; i < fftSize; i++) {

--- a/src/spectrogramplot.h
+++ b/src/spectrogramplot.h
@@ -68,6 +68,7 @@ public:
     void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
     void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
     bool mouseEvent(QEvent::Type type, QMouseEvent *event) override;
+    void leaveEvent();
     std::shared_ptr<SampleSource<std::complex<float>>> input() { return inputSource; };
     void setSampleRate(double sampleRate);
     bool tunerEnabled();

--- a/src/spectrogramplot.h
+++ b/src/spectrogramplot.h
@@ -33,8 +33,29 @@
 #include <math.h>
 #include <vector>
 
-class TileCacheKey;
 class AnnotationLocation;
+
+
+class TileCacheKey
+{
+
+public:
+    TileCacheKey(int fftSize, int zoomLevel, size_t sample) {
+        this->fftSize = fftSize;
+        this->zoomLevel = zoomLevel;
+        this->sample = sample;
+    }
+
+    bool operator==(const TileCacheKey &k2) const {
+        return (this->fftSize == k2.fftSize) &&
+               (this->zoomLevel == k2.zoomLevel) &&
+               (this->sample == k2.sample);
+    }
+
+    int fftSize;
+    int zoomLevel;
+    size_t sample;
+};
 
 class SpectrogramPlot : public Plot
 {
@@ -94,27 +115,6 @@ private:
     int linesPerTile();
     void paintFrequencyScale(QPainter &painter, QRect &rect);
     void paintAnnotations(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
-};
-
-class TileCacheKey
-{
-
-public:
-    TileCacheKey(int fftSize, int zoomLevel, size_t sample) {
-        this->fftSize = fftSize;
-        this->zoomLevel = zoomLevel;
-        this->sample = sample;
-    }
-
-    bool operator==(const TileCacheKey &k2) const {
-        return (this->fftSize == k2.fftSize) &&
-               (this->zoomLevel == k2.zoomLevel) &&
-               (this->sample == k2.sample);
-    }
-
-    int fftSize;
-    int zoomLevel;
-    size_t sample;
 };
 
 class AnnotationLocation

--- a/src/spectrogramplot.h
+++ b/src/spectrogramplot.h
@@ -67,7 +67,7 @@ public:
     std::shared_ptr<AbstractSampleSource> output() override;
     void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
     void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
-    bool mouseEvent(QEvent::Type type, QMouseEvent event) override;
+    bool mouseEvent(QEvent::Type type, QMouseEvent *event) override;
     std::shared_ptr<SampleSource<std::complex<float>>> input() { return inputSource; };
     void setSampleRate(double sampleRate);
     bool tunerEnabled();

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -64,7 +64,11 @@ QPixmap TracePlot::getTile(size_t tileID, size_t sampleCount)
 
     if (!tasks.contains(key)) {
         range_t<size_t> sampleRange{tileID * sampleCount, (tileID + 1) * sampleCount};
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QtConcurrent::run(&TracePlot::drawTile, this, key, QRect(0, 0, tileWidth, height()), sampleRange);
+#else
         QtConcurrent::run(this, &TracePlot::drawTile, key, QRect(0, 0, tileWidth, height()), sampleRange);
+#endif
         tasks.insert(key);
     }
     pixmap.fill(Qt::transparent);

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -90,25 +90,55 @@ void TracePlot::drawTile(QString key, const QRect &rect, range_t<size_t> sampleR
     auto firstSample = sampleRange.minimum;
     auto length = sampleRange.length();
 
+    // Clamp the request to what the source actually has, shrinking the draw
+    // rect proportionally. Without this, at high zoom samplesPerTile can
+    // exceed the file size; getSamples then returns nullptr, drawTile bails
+    // before emitting an image, and the tile stays fully transparent -- the
+    // "trace plot disappears at high zoom" symptom. The spectrogram already
+    // handles this case (zero-pads to -inf); TracePlot was the outlier.
+    QRect drawRect = rect;
+    auto clampToAvailable = [&](size_t available) -> bool {
+        if (firstSample >= available)
+            return false;
+        if (firstSample + length > available) {
+            size_t valid = available - firstSample;
+            drawRect.setWidth(int(double(rect.width()) * valid / length));
+            length = valid;
+        }
+        return true;
+    };
+
     // Is it a 2-channel (complex) trace?
     if (auto src = dynamic_cast<SampleSource<std::complex<float>>*>(sampleSource.get())) {
-        auto samples = src->getSamples(firstSample, length);
-        if (samples == nullptr)
+        if (!clampToAvailable(src->count())) {
+            emit imageReady(key, image);
             return;
+        }
+        auto samples = src->getSamples(firstSample, length);
+        if (samples == nullptr) {
+            emit imageReady(key, image);
+            return;
+        }
 
         painter.setPen(Qt::red);
-        plotTrace(painter, rect, reinterpret_cast<float*>(samples.get()), length, 2);
+        plotTrace(painter, drawRect, reinterpret_cast<float*>(samples.get()), length, 2);
         painter.setPen(Qt::blue);
-        plotTrace(painter, rect, reinterpret_cast<float*>(samples.get())+1, length, 2);
+        plotTrace(painter, drawRect, reinterpret_cast<float*>(samples.get())+1, length, 2);
 
     // Otherwise is it single channel?
     } else if (auto src = dynamic_cast<SampleSource<float>*>(sampleSource.get())) {
-        auto samples = src->getSamples(firstSample, length);
-        if (samples == nullptr)
+        if (!clampToAvailable(src->count())) {
+            emit imageReady(key, image);
             return;
+        }
+        auto samples = src->getSamples(firstSample, length);
+        if (samples == nullptr) {
+            emit imageReady(key, image);
+            return;
+        }
 
         painter.setPen(Qt::green);
-        plotTrace(painter, rect, samples.get(), length, 1);
+        plotTrace(painter, drawRect, samples.get(), length, 1);
     } else {
         throw std::runtime_error("TracePlot::paintMid: Unsupported source type");
     }

--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -32,11 +32,19 @@ void TracePlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleR
 {
     if (sampleRange.length() == 0) return;
 
-    int samplesPerColumn = std::max(1UL, sampleRange.length() / rect.width());
-    int samplesPerTile = tileWidth * samplesPerColumn;
+    // Prefer the explicit samples-per-column set by PlotView so we share the
+    // same x-axis scale as the spectrogram (governed by fftSize / zoomLevel).
+    // Computing it locally as sampleRange.length() / rect.width() goes wrong
+    // when viewRange is clamped to a small file -- the trace stretches across
+    // the full viewport while the spectrogram fills only the leading pixels,
+    // and the two panels visibly disagree on the time axis.
+    int spc = samplesPerColumn > 0
+        ? samplesPerColumn
+        : std::max(1, int(sampleRange.length() / rect.width()));
+    int samplesPerTile = tileWidth * spc;
     size_t tileID = sampleRange.minimum / samplesPerTile;
     size_t tileOffset = sampleRange.minimum % samplesPerTile; // Number of samples to skip from first image tile
-    int xOffset = tileOffset / samplesPerColumn; // Number of columns to skip from first image tile
+    int xOffset = tileOffset / spc; // Number of columns to skip from first image tile
 
     // Paint first (possibly partial) tile
     painter.drawPixmap(

--- a/src/traceplot.h
+++ b/src/traceplot.h
@@ -32,6 +32,7 @@ public:
 
     void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     std::shared_ptr<AbstractSampleSource> source() { return sampleSource; };
+    void setSamplesPerColumn(int spc) { samplesPerColumn = std::max(1, spc); }
 
 signals:
     void imageReady(QString key, QImage image);
@@ -42,6 +43,11 @@ public slots:
 private:
     QSet<QString> tasks;
     const int tileWidth = 1000;
+    // Samples per pixel, fed in by PlotView so we stay aligned with the
+    // spectrogram (which uses fftSize / zoomLevel). 0 falls back to the legacy
+    // "stretch sampleRange to fill rect" behaviour for back-compat with any
+    // future TracePlot not driven by PlotView.
+    int samplesPerColumn = 0;
 
     QPixmap getTile(size_t tileID, size_t sampleCount);
     void drawTile(QString key, const QRect &rect, range_t<size_t> sampleRange);

--- a/src/tuner.cpp
+++ b/src/tuner.cpp
@@ -63,7 +63,7 @@ int Tuner::deviation()
     return _deviation;
 }
 
-bool Tuner::mouseEvent(QEvent::Type type, QMouseEvent event)
+bool Tuner::mouseEvent(QEvent::Type type, QMouseEvent *event)
 {
     if (cfCursor->mouseEvent(type, event))
         return true;

--- a/src/tuner.cpp
+++ b/src/tuner.cpp
@@ -75,6 +75,13 @@ bool Tuner::mouseEvent(QEvent::Type type, QMouseEvent *event)
     return false;
 }
 
+void Tuner::leaveEvent()
+{
+    cfCursor->leaveEvent();
+    minCursor->leaveEvent();
+    maxCursor->leaveEvent();
+}
+
 void Tuner::paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
     painter.save();

--- a/src/tuner.h
+++ b/src/tuner.h
@@ -35,6 +35,7 @@ public:
     int centre();
     int deviation();
     bool mouseEvent(QEvent::Type, QMouseEvent *event);
+    void leaveEvent();
     void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     void setCentre(int centre);
     void setDeviation(int dev);

--- a/src/tuner.h
+++ b/src/tuner.h
@@ -34,7 +34,7 @@ public:
     Tuner(int height, QObject * parent);
     int centre();
     int deviation();
-    bool mouseEvent(QEvent::Type, QMouseEvent event);
+    bool mouseEvent(QEvent::Type, QMouseEvent *event);
     void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     void setCentre(int centre);
     void setDeviation(int dev);


### PR DESCRIPTION
Four related bugs that surface together when inspecting short SigMF captures
with a derived plot (amplitude / IFR / ...) panel added beneath the spectrogram.
Each commit is self-contained.

### 1. TracePlot drew on a different x-scale than the spectrogram
When `viewRange` got clamped to a small file, `TracePlot::paintMid` computed
`samplesPerColumn = sampleRange.length() / rect.width()` while the spectrogram
used `fftSize / zoomLevel`. The two panels drew the same samples at different
x positions. PlotView now pushes its global samples-per-column into each
TracePlot via a new `setSamplesPerColumn` setter (with a fallback to the
legacy local computation for any non-PlotView caller).

### 2. TracePlot vanished at high zoom
`samplesPerTile` could exceed the file size, `InputSource::getSamples`
returned `nullptr`, and `drawTile` returned without emitting an image — so
QPixmapCache never got a tile and the panel stayed transparent. Now `drawTile`
clamps the request to what the source actually has, shrinks the draw rect
proportionally so the visible samples occupy their natural pixel range, and
always emits the image.

### 3. Spectrogram clipped fftSize/2 samples before EOF
The centred FFT couldn't be computed for the last `fftSize/2` samples;
`getLine` filled the column with `-inf`. The spectrogram visibly ended short
of the trace plots' right edge. `getLine` now zero-pads the partial buffer
at EOF so the spectrogram and trace plots stop at the same x-pixel.

### 4. Cursors lost their sample range under zoom
Cursors store viewport-pixel positions; `setFFTAndZoom` changed
`samplesPerColumn` without re-anchoring them, so the "Symbol rate" / "Period"
readout drifted just because the user zoomed. `setFFTAndZoom` now snapshots
the cursors' absolute sample range at the top and re-places the cursors on
the new pixel grid at the end, after `updateView()` has settled the
scrollbars.

### Test plan
- Visual: load a short SigMF capture (e.g. a 3 ms extracted pulse at 1 MS/s),
  right-click → Add derived plot → Add amplitude, Ctrl-scroll to zoom from
  1× to maximum. Both panels stay aligned at every zoom level and the trace
  remains visible end-to-end.
- Cursor stability: enable cursors over a known symbol period, note the
  "Symbol rate" / "Period" readout, zoom in and out. Readout stays put.
- Spectrogram EOF: scroll to the right edge of the file; the spectrogram now
  reaches the same x-pixel as the derived plot.
